### PR TITLE
Session/12

### DIFF
--- a/Yumemi-ios-training/Yumemi-ios-training/Presenter/WeatherPresenter.swift
+++ b/Yumemi-ios-training/Yumemi-ios-training/Presenter/WeatherPresenter.swift
@@ -11,9 +11,9 @@ protocol WeatherPresenterProtocolInput {
     func fetchWeather()
 }
 
-protocol WeatherPresenterProtocolOutput: AnyObject {
-    @MainActor func showWeather(weatherResponse: WeatherResponse)
-    @MainActor func showErrorAlert(with message: String?)
+@MainActor protocol WeatherPresenterProtocolOutput: AnyObject {
+    func showWeather(weatherResponse: WeatherResponse)
+    func showErrorAlert(with message: String?)
     func startIndicatorAnimating()
     func stopIndicatorAnimating()
 }
@@ -29,11 +29,11 @@ class WeatherPresenter: WeatherPresenterProtocolInput {
     }
     
     func fetchWeather() {
-        view?.startIndicatorAnimating()
         Task {
+            await self.view?.startIndicatorAnimating()
             defer {
-                DispatchQueue.main.async {
-                    self.view?.stopIndicatorAnimating()
+                Task {
+                    await self.view?.stopIndicatorAnimating()
                 }
             }
             switch await self.model.fetchWeather() {

--- a/Yumemi-ios-training/Yumemi-ios-training/View/WeatherViewController.swift
+++ b/Yumemi-ios-training/Yumemi-ios-training/View/WeatherViewController.swift
@@ -28,7 +28,9 @@ class WeatherViewController: UIViewController {
     }
     
     @IBAction func reloadWeather(_ sender: Any) {
-        presenter.fetchWeather()
+        Task {
+            await presenter.fetchWeather()
+        }
     }
     
     @IBAction func closeWeatherView(_ sender: Any) {
@@ -36,11 +38,13 @@ class WeatherViewController: UIViewController {
     }
     
     @objc func viewWillEnterForeground(_ notification: Notification) {
-        presenter.fetchWeather()
+        Task {
+            await presenter.fetchWeather()
+        }
     }
 }
 
-extension WeatherViewController: WeatherPresenterProtocolOutput {
+@MainActor extension WeatherViewController: WeatherPresenterProtocolOutput {
     func showErrorAlert(with message: String?) {
         let alert = UIAlertController(title: R.string.message.alertControllerTitle(), message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: R.string.message.alertActionTitle(), style: .default))

--- a/Yumemi-ios-training/Yumemi-ios-training/View/WeatherViewController.swift
+++ b/Yumemi-ios-training/Yumemi-ios-training/View/WeatherViewController.swift
@@ -40,14 +40,14 @@ class WeatherViewController: UIViewController {
     }
 }
 
-extension WeatherViewController: WeatherPresenterProtocolOutput {
-    @MainActor func showErrorAlert(with message: String?) {
+@MainActor extension WeatherViewController: WeatherPresenterProtocolOutput {
+    func showErrorAlert(with message: String?) {
         let alert = UIAlertController(title: R.string.message.alertControllerTitle(), message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: R.string.message.alertActionTitle(), style: .default))
         present(alert, animated: true)
     }
     
-    @MainActor func showWeather(weatherResponse: WeatherResponse) {
+    func showWeather(weatherResponse: WeatherResponse) {
         switch weatherResponse.weather {
         case .sunny:
             weatherImageView.image = R.image.sunny()

--- a/Yumemi-ios-training/Yumemi-ios-training/View/WeatherViewController.swift
+++ b/Yumemi-ios-training/Yumemi-ios-training/View/WeatherViewController.swift
@@ -28,9 +28,7 @@ class WeatherViewController: UIViewController {
     }
     
     @IBAction func reloadWeather(_ sender: Any) {
-        Task {
-            await presenter.fetchWeather()
-        }
+        presenter.fetchWeather()
     }
     
     @IBAction func closeWeatherView(_ sender: Any) {
@@ -38,20 +36,18 @@ class WeatherViewController: UIViewController {
     }
     
     @objc func viewWillEnterForeground(_ notification: Notification) {
-        Task {
-            await presenter.fetchWeather()
-        }
+        presenter.fetchWeather()
     }
 }
 
-@MainActor extension WeatherViewController: WeatherPresenterProtocolOutput {
-    func showErrorAlert(with message: String?) {
+extension WeatherViewController: WeatherPresenterProtocolOutput {
+    @MainActor func showErrorAlert(with message: String?) {
         let alert = UIAlertController(title: R.string.message.alertControllerTitle(), message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: R.string.message.alertActionTitle(), style: .default))
         present(alert, animated: true)
     }
     
-    func showWeather(weatherResponse: WeatherResponse) {
+    @MainActor func showWeather(weatherResponse: WeatherResponse) {
         switch weatherResponse.weather {
         case .sunny:
             weatherImageView.image = R.image.sunny()

--- a/Yumemi-ios-training/Yumemi-ios-trainingTests/WeatherViewTests.swift
+++ b/Yumemi-ios-training/Yumemi-ios-trainingTests/WeatherViewTests.swift
@@ -28,7 +28,7 @@ class WeatherViewTests: XCTestCase {
         XCTAssertEqual(viewController?.activityIndicatorView.isAnimating, true) // インジケータが表示されるとpresenter.fetchWeather()が呼ばれていることがわかる
     }
     
-    func testShowInvalidParameterErrorAlert() {
+    @MainActor func testShowInvalidParameterErrorAlert() {
         viewController?.showErrorAlert(with: R.string.message.invalidParameterError())
         XCTAssertTrue(viewController?.presentedViewController is UIAlertController)
         XCTAssertEqual(viewController?.presentedViewController?.title, R.string.message.alertControllerTitle())
@@ -36,7 +36,7 @@ class WeatherViewTests: XCTestCase {
         XCTAssertEqual((viewController?.presentedViewController as? UIAlertController)?.message, R.string.message.invalidParameterError())
     }
     
-    func testShowUnknownErrorAlert() {
+    @MainActor func testShowUnknownErrorAlert() {
         viewController?.showErrorAlert(with: R.string.message.unknownError())
         XCTAssertTrue(viewController?.presentedViewController is UIAlertController)
         XCTAssertEqual(viewController?.presentedViewController?.title, R.string.message.alertControllerTitle())
@@ -44,28 +44,28 @@ class WeatherViewTests: XCTestCase {
         XCTAssertEqual((viewController?.presentedViewController as? UIAlertController)?.message, R.string.message.unknownError())
     }
     
-    func testShowSunnyImageWhenResponseIsSunny() {
+    @MainActor func testShowSunnyImageWhenResponseIsSunny() {
         viewController?.showWeather(weatherResponse: WeatherResponse(weather: .sunny, maxTemp: 0, minTemp: 0, date: Date()))
         XCTAssertNotNil(viewController?.weatherImageView)
         XCTAssertEqual(viewController?.weatherImageView.image, R.image.sunny())
         XCTAssertEqual(viewController?.activityIndicatorView.isAnimating, false)
     }
     
-    func testShowCloudyImageWhenResponseIsCloudy() {
+    @MainActor func testShowCloudyImageWhenResponseIsCloudy() {
         viewController?.showWeather(weatherResponse: WeatherResponse(weather: .cloudy, maxTemp: 0, minTemp: 0, date: Date()))
         XCTAssertNotNil(viewController?.weatherImageView)
         XCTAssertEqual(viewController?.weatherImageView.image, R.image.cloudy())
         XCTAssertEqual(viewController?.activityIndicatorView.isAnimating, false)
     }
     
-    func testShowRainyImageWhenResponseIsRainy() {
+    @MainActor func testShowRainyImageWhenResponseIsRainy() {
         viewController?.showWeather(weatherResponse: WeatherResponse(weather: .rainy, maxTemp: 0, minTemp: 0, date: Date()))
         XCTAssertNotNil(viewController?.weatherImageView)
         XCTAssertEqual(viewController?.weatherImageView.image, R.image.rainy())
         XCTAssertEqual(viewController?.activityIndicatorView.isAnimating, false)
     }
     
-    func testShowTemperatureLabel() {
+    @MainActor func testShowTemperatureLabel() {
         viewController?.showWeather(weatherResponse: WeatherResponse(weather: .sunny, maxTemp: 10, minTemp: 5, date: Date()))
         XCTAssertNotNil(viewController?.maxTemperatureLabel)
         XCTAssertNotNil(viewController?.minTemperatureLabel)
@@ -74,31 +74,25 @@ class WeatherViewTests: XCTestCase {
         XCTAssertEqual(viewController?.activityIndicatorView.isAnimating, false)
     }
     
-    func testResponseUnknownError() {
+    func testResponseUnknownError() async {
         model.jsonDecoder.dateDecodingStrategy = .secondsSince1970 // iso8601以外を指定
-        model.fetchWeather { [weak self] result in
-            guard self == self else { return }
-            switch result {
-            case .success(_):
-                XCTFail("\(#function) fail")
-            case .failure(let error):
-                XCTAssertEqual(error, APIError.unknownError)
-                XCTAssertEqual(error.errorDescription, R.string.message.unknownError())
-            }
+        switch await model.fetchWeather() {
+        case .success(_):
+            XCTFail("\(#function) fail")
+        case .failure(let error):
+            XCTAssertEqual(error, APIError.unknownError)
+            XCTAssertEqual(error.errorDescription, R.string.message.unknownError())
         }
     }
     
-    func testResponseInvalidParameterError() {
+    func testResponseInvalidParameterError() async {
         model.jsonEncoder.dateEncodingStrategy = .secondsSince1970 // iso8601以外を指定
-        model.fetchWeather { [weak self] result in
-            guard self == self else { return }
-            switch result {
-            case .success(_):
-                XCTFail("\(#function) fail")
-            case .failure(let error):
-                XCTAssertEqual(error, APIError.invalidParameterError)
-                XCTAssertEqual(error.errorDescription, R.string.message.invalidParameterError())
-            }
+        switch await model.fetchWeather() {
+        case .success(_):
+            XCTFail("\(#function) fail")
+        case .failure(let error):
+            XCTAssertEqual(error, APIError.invalidParameterError)
+            XCTAssertEqual(error.errorDescription, R.string.message.invalidParameterError())
         }
     }
 }


### PR DESCRIPTION
# やったこと
- async/awaitを使ってYumemiWeather.asyncFetchWeather()から天気情報を取得し、結果をviewに表示

# 課題へのリンク
- [session12](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Concurrency.md)

# API 仕様へのリンク
- [YumemiWeather](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/YumemiWeather.md)

# 実行画面
今回はなし

# 懸念点
- defer{}では`await MainActor.run{}`が使えない
  - 今のところ`DispatchQueue.main.async`でインジケータを非表示にする処理を書いている
  - 他に方法はないか
  - presenter内のfetchWeather()のswitchでインジケータを非表示するコードを書く手もあるが、success/failureで同じコードを書くことになる